### PR TITLE
Reset _bMovieDone to NO when the method stop() is called.

### DIFF
--- a/src/ofxAVFVideoRenderer.m
+++ b/src/ofxAVFVideoRenderer.m
@@ -352,6 +352,7 @@ int count = 0;
     // Pause and rewind.
     [self.player pause];
     [self.player seekToTime:kCMTimeZero];
+    _bMovieDone = NO;
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Hi,

It seems to me that the boolean _bMovieDone should be set to NO when the method stop() is called.
Even more so as the position of the player is set to 0 in this method too.

Let me know.

Thanks,

Hugues.
