### PR TITLE
Memory fixes

### DIFF
--- a/example-audioData/src/testApp.cpp
+++ b/example-audioData/src/testApp.cpp
@@ -9,6 +9,9 @@ void testApp::setup()
 {
     ofSetVerticalSync(true);
 
+	// explicitly tell it to load audio (default)
+	videoPlayer.setShouldLoadAudio(true);
+	
 //    videoPlayer.loadMovie("Casey_You_need_noise.mov");
 //    videoPlayer.loadMovie("fingers.mov");
     videoPlayer.loadMovie("cat.mp4");

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -6,6 +6,6 @@
 int main()
 {
     ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 1920, 1080, OF_WINDOW);
-	ofRunApp(new testApp());
+    ofSetupOpenGL(&window, 1920, 1080, OF_WINDOW);
+    ofRunApp(new testApp());
 }

--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -1,11 +1,23 @@
 #include "testApp.h"
 
+// cleanup
+testApp::~testApp()
+{
+	ofLogNotice() << "cleanup";
+	deleteMovie();
+}
+
 //--------------------------------------------------------------
 void testApp::setup()
 {
     ofSetVerticalSync(true);
     ofBackground(0);
-    
+	
+	videop = NULL;
+	
+	// explicitly tell it to load audio (default)
+	video.setShouldLoadAudio(true);
+	
     video.loadMovie("test.mov");
     video.play();
     video.setLoopState(OF_LOOP_NORMAL);
@@ -21,6 +33,10 @@ void testApp::update()
     if (video.isFrameNew()) {
         image.setFromPixels(video.getPixelsRef());
     }
+	
+	if (videop != NULL) {
+		videop->update();
+	}
 }
 
 //--------------------------------------------------------------
@@ -77,10 +93,40 @@ void testApp::keyPressed(int key)
         case OF_KEY_DOWN:
             video.setSpeed(video.getSpeed() * 0.9);
             break;
-            
+			
+		case 'c':
+			ofLogNotice() << "create a new movie";
+			
+			deleteMovie();
+			
+			//create video
+			videop = new ofxAVFVideoPlayer;
+			videop->setShouldLoadAudio(true);
+			
+			videop->loadMovie("test.mov");
+			
+			// dont start the movie
+			// it will get cleaned up anyway
+//			videop->play();
+			break;
+			
+			
+		case 'd':
+			//destroy video
+			ofLogNotice() << "destroy the movie";
+			deleteMovie();
+			
         default:
             break;
     }
+}
+
+//--------------------------------------------------------------
+void testApp::deleteMovie(){
+	if (videop != NULL) {
+		delete videop;
+		videop = NULL;
+	}
 }
 
 //--------------------------------------------------------------

--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -3,8 +3,8 @@
 // cleanup
 testApp::~testApp()
 {
-	ofLogNotice() << "cleanup";
-	deleteMovie();
+    ofLogNotice() << "cleanup";
+    deleteMovie();
 }
 
 //--------------------------------------------------------------
@@ -13,10 +13,10 @@ void testApp::setup()
     ofSetVerticalSync(true);
     ofBackground(0);
 	
-	videop = NULL;
+    videop = NULL;
 	
-	// explicitly tell it to load audio (default)
-	video.setShouldLoadAudio(true);
+    // explicitly tell it to load audio (default)
+    video.setShouldLoadAudio(true);
 	
     video.loadMovie("test.mov");
     video.play();
@@ -34,17 +34,17 @@ void testApp::update()
         image.setFromPixels(video.getPixelsRef());
     }
 	
-	if (videop != NULL) {
-		videop->update();
-	}
+    if (videop != NULL) {
+        videop->update();
+    }
 }
 
 //--------------------------------------------------------------
 void testApp::draw()
 {
     video.draw(0, 0);
-	if(image.bAllocated()){
-		image.draw(video.getWidth(), 0);
+    if(image.bAllocated()){
+        image.draw(video.getWidth(), 0);
     }
 	
     // Draw a timeline at the bottom of the screen.
@@ -94,27 +94,27 @@ void testApp::keyPressed(int key)
             video.setSpeed(video.getSpeed() * 0.9);
             break;
 			
-		case 'c':
-			ofLogNotice() << "create a new movie";
-			
-			deleteMovie();
-			
-			//create video
-			videop = new ofxAVFVideoPlayer;
-			videop->setShouldLoadAudio(true);
-			
-			videop->loadMovie("test.mov");
-			
-			// dont start the movie
-			// it will get cleaned up anyway
-//			videop->play();
-			break;
-			
-			
-		case 'd':
-			//destroy video
-			ofLogNotice() << "destroy the movie";
-			deleteMovie();
+        case 'c':
+            ofLogNotice() << "create a new movie";
+            
+            deleteMovie();
+            
+            //create video
+            videop = new ofxAVFVideoPlayer;
+            videop->setShouldLoadAudio(true);
+            
+            videop->loadMovie("test.mov");
+            
+            // dont start the movie
+            // it will get cleaned up anyway
+//            videop->play();
+            break;
+            
+            
+        case 'd':
+            //destroy video
+            ofLogNotice() << "destroy the movie";
+            deleteMovie();
 			
         default:
             break;

--- a/example/src/testApp.h
+++ b/example/src/testApp.h
@@ -6,6 +6,9 @@
 class testApp : public ofBaseApp
 {
 	public:
+	
+		~testApp();
+	
 		void setup();
 		void update();
 		void draw();
@@ -19,7 +22,11 @@ class testApp : public ofBaseApp
 		void windowResized(int w, int h);
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
-    
+	
+		void deleteMovie();
+	
         ofxAVFVideoPlayer video;
         ofImage image;
+	
+		ofxAVFVideoPlayer* videop;
 };

--- a/example/src/testApp.h
+++ b/example/src/testApp.h
@@ -5,28 +5,28 @@
 
 class testApp : public ofBaseApp
 {
-	public:
+    public:
 	
-		~testApp();
-	
-		void setup();
-		void update();
-		void draw();
+        ~testApp();
 
-		void keyPressed(int key);
-		void keyReleased(int key);
-		void mouseMoved(int x, int y);
-		void mouseDragged(int x, int y, int button);
-		void mousePressed(int x, int y, int button);
-		void mouseReleased(int x, int y, int button);
-		void windowResized(int w, int h);
-		void dragEvent(ofDragInfo dragInfo);
-		void gotMessage(ofMessage msg);
-	
-		void deleteMovie();
-	
+        void setup();
+        void update();
+        void draw();
+
+        void keyPressed(int key);
+        void keyReleased(int key);
+        void mouseMoved(int x, int y);
+        void mouseDragged(int x, int y, int button);
+        void mousePressed(int x, int y, int button);
+        void mouseReleased(int x, int y, int button);
+        void windowResized(int w, int h);
+        void dragEvent(ofDragInfo dragInfo);
+        void gotMessage(ofMessage msg);
+
+        void deleteMovie();
+
         ofxAVFVideoPlayer video;
         ofImage image;
-	
-		ofxAVFVideoPlayer* videop;
+
+        ofxAVFVideoPlayer* videop;
 };

--- a/src/ofxAVFVideoPlayer.h
+++ b/src/ofxAVFVideoPlayer.h
@@ -52,6 +52,8 @@ public:
     
     bool                isLoading();
     bool                isLoaded();
+	bool				shouldLoadAudio();
+	void				setShouldLoadAudio(bool doLoadAudio);
     bool                isAudioLoaded();
     bool                errorLoading();
     
@@ -101,6 +103,7 @@ protected:
     
     bool bPaused;
 	bool bShouldPlay;
+	bool bShouldLoadAudio;
 	
 	float scrubToTime;
     bool bNewFrame;

--- a/src/ofxAVFVideoPlayer.h
+++ b/src/ofxAVFVideoPlayer.h
@@ -35,7 +35,7 @@ public:
     float               getAmplitudeAt(float pos, int channel = 0);
     float *             getAllAmplitudes();
     int                 getNumAmplitudes();
-	
+    
     bool                isFrameNew(); //returns true if the frame has changed in this update cycle
     
     // Returns openFrameworks compatible RGBA pixels.
@@ -52,8 +52,8 @@ public:
     
     bool                isLoading();
     bool                isLoaded();
-	bool				shouldLoadAudio();
-	void				setShouldLoadAudio(bool doLoadAudio);
+    bool                shouldLoadAudio();
+    void                setShouldLoadAudio(bool doLoadAudio);
     bool                isAudioLoaded();
     bool                errorLoading();
     
@@ -72,7 +72,7 @@ public:
     float               getVolume();
     
     void                setPosition(float pct);
-	void                setTime(float seconds);
+    void                setTime(float seconds);
     void                setPositionInSeconds(float seconds);
     void                setFrame(int frame); // frame 0 = first frame...
     void                setBalance(float balance);
@@ -102,10 +102,10 @@ protected:
     bool bTheFutureIsNow;
     
     bool bPaused;
-	bool bShouldPlay;
-	bool bShouldLoadAudio;
-	
-	float scrubToTime;
+    bool bShouldPlay;
+    bool bShouldLoadAudio;
+    
+    float scrubToTime;
     bool bNewFrame;
     bool bHavePixelsChanged;
     

--- a/src/ofxAVFVideoPlayer.mm
+++ b/src/ofxAVFVideoPlayer.mm
@@ -25,6 +25,7 @@ ofxAVFVideoPlayer::ofxAVFVideoPlayer()
     currentLoopState = OF_LOOP_NORMAL;
     
     bTheFutureIsNow = false;
+	bShouldLoadAudio = false; // maybe: dont change previouse default behaviour and set this to true
 }
 
 //--------------------------------------------------------------
@@ -46,6 +47,7 @@ bool ofxAVFVideoPlayer::loadMovie(string path)
     moviePlayer = [[AVFVideoRenderer alloc] init];
     [moviePlayer setUseAlpha:(pixelFormat == OF_PIXELS_RGBA)];
     [moviePlayer setUseTexture:YES];
+	[moviePlayer setShouldLoadAudio:bShouldLoadAudio];
     
     bTheFutureIsNow = moviePlayer.theFutureIsNow;
 
@@ -286,6 +288,18 @@ bool ofxAVFVideoPlayer::isLoading()
 bool ofxAVFVideoPlayer::isLoaded()
 {
     return bInitialized;
+}
+
+//--------------------------------------------------------------
+bool ofxAVFVideoPlayer::shouldLoadAudio()
+{
+	return bShouldLoadAudio;
+}
+
+//--------------------------------------------------------------
+void ofxAVFVideoPlayer::setShouldLoadAudio(bool doLoadAudio)
+{
+	bShouldLoadAudio = doLoadAudio;
 }
 
 //--------------------------------------------------------------

--- a/src/ofxAVFVideoPlayer.mm
+++ b/src/ofxAVFVideoPlayer.mm
@@ -13,11 +13,11 @@
 ofxAVFVideoPlayer::ofxAVFVideoPlayer()
 {
     moviePlayer = NULL;
-	bNewFrame = false;
+    bNewFrame = false;
     bPaused = true;
-	duration = 0.0f;
+    duration = 0.0f;
     speed = 1.0f;
-	
+    
     scrubToTime = 0.0;
     bInitialized = false;
     
@@ -25,13 +25,13 @@ ofxAVFVideoPlayer::ofxAVFVideoPlayer()
     currentLoopState = OF_LOOP_NORMAL;
     
     bTheFutureIsNow = false;
-	bShouldLoadAudio = true; // maybe: change previous default behaviour: explicitly wanting to load audio
+    bShouldLoadAudio = true; // maybe: change previous default behaviour: explicitly wanting to load audio
 }
 
 //--------------------------------------------------------------
 ofxAVFVideoPlayer::~ofxAVFVideoPlayer()
 {
-	close();
+    close();
 }
 
 //--------------------------------------------------------------
@@ -41,17 +41,17 @@ bool ofxAVFVideoPlayer::loadMovie(string path)
     if (bInitialized) {
         close();
     }
-	
-	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-	
+    
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+    
     moviePlayer = [[AVFVideoRenderer alloc] init];
     [moviePlayer setUseAlpha:(pixelFormat == OF_PIXELS_RGBA)];
     [moviePlayer setUseTexture:YES];
-	[moviePlayer setShouldLoadAudio:bShouldLoadAudio];
+    [moviePlayer setShouldLoadAudio:bShouldLoadAudio];
     
     bTheFutureIsNow = moviePlayer.theFutureIsNow;
 
-	if (Poco::icompare(path.substr(0, 7), "http://")  == 0 ||
+    if (Poco::icompare(path.substr(0, 7), "http://")  == 0 ||
         Poco::icompare(path.substr(0, 8), "https://") == 0 ||
         Poco::icompare(path.substr(0, 7), "rtsp://")  == 0) {
         [moviePlayer loadURLPath:[NSString stringWithUTF8String:path.c_str()]];
@@ -60,7 +60,7 @@ bool ofxAVFVideoPlayer::loadMovie(string path)
         path = ofToDataPath(path, false);
         [moviePlayer loadFilePath:[NSString stringWithUTF8String:path.c_str()]];
     }
-	[pool release];
+    [pool release];
     
     bShouldPlay = false;
     return true;
@@ -76,17 +76,16 @@ void ofxAVFVideoPlayer::closeMovie()
 void ofxAVFVideoPlayer::close()
 {
     pixels.clear();
-	
+    
     if (moviePlayer != nil) {
-		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-		
-		// finalize movieplayer!!
-		// problems when just releasing the object
-		// due to retained moviePlayer
-		// if loading audio and it never got played timeObserver retains moviePlayer
-		[moviePlayer finalize];
+        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+        
+        // finalize the movieplayer
+        // if loading audio and it never got played timeObserver retains moviePlayer
+        // using a finalizeing solves this
+        [moviePlayer finalize];
         moviePlayer = nil;
-		[pool release];
+        [pool release];
 
     }
     
@@ -116,14 +115,14 @@ void ofxAVFVideoPlayer::update()
             bInitialized = true;
 
             if (scrubToTime != 0.0f) {
-				setTime(scrubToTime);
-				scrubToTime = 0.0f;
-			}
+                setTime(scrubToTime);
+                scrubToTime = 0.0f;
+            }
             
-			if (bShouldPlay){
-				play();
-				bShouldPlay = false;
-			}
+            if (bShouldPlay){
+                play();
+                bShouldPlay = false;
+            }
         }
         
         if (bTheFutureIsNow) {
@@ -146,13 +145,13 @@ void ofxAVFVideoPlayer::update()
 //--------------------------------------------------------------
 void ofxAVFVideoPlayer::play()
 {
-	if (bInitialized) {
+    if (bInitialized) {
         ofLogVerbose("ofxAVFVideoPlayer::play()") << "Initialized and playing at time " << getCurrentTime();
-		[moviePlayer play];
-	}
-	else {
-		bShouldPlay = true;
-	}
+        [moviePlayer play];
+    }
+    else {
+        bShouldPlay = true;
+    }
 }
 
 //--------------------------------------------------------------
@@ -250,7 +249,7 @@ ofPixelsRef ofxAVFVideoPlayer::getPixelsRef()
         getPixels();
     }
     
-	return pixels;
+    return pixels;
 }
 
 //--------------------------------------------------------------
@@ -298,13 +297,13 @@ bool ofxAVFVideoPlayer::isLoaded()
 //--------------------------------------------------------------
 bool ofxAVFVideoPlayer::shouldLoadAudio()
 {
-	return bShouldLoadAudio;
+    return bShouldLoadAudio;
 }
 
 //--------------------------------------------------------------
 void ofxAVFVideoPlayer::setShouldLoadAudio(bool doLoadAudio)
 {
-	bShouldLoadAudio = doLoadAudio;
+    bShouldLoadAudio = doLoadAudio;
 }
 
 //--------------------------------------------------------------
@@ -392,7 +391,7 @@ ofLoopType ofxAVFVideoPlayer::getLoopState()
     if (moviePlayer && [moviePlayer loops])
         return OF_LOOP_NORMAL;
     
-	return OF_LOOP_NONE;
+    return OF_LOOP_NONE;
 }
 
 //--------------------------------------------------------------
@@ -414,13 +413,13 @@ void ofxAVFVideoPlayer::setPosition(float pct)
 //--------------------------------------------------------------
 void ofxAVFVideoPlayer::setTime(float position)
 {
-	if (![moviePlayer isLoaded]) {
-		ofLogNotice("ofxAVFVideoPlayer::setCurrentTime()") << "Video player not ready, declaring to scrub to time " << scrubToTime;
-		scrubToTime = position;
-	}
-	else {
+    if (![moviePlayer isLoaded]) {
+        ofLogNotice("ofxAVFVideoPlayer::setCurrentTime()") << "Video player not ready, declaring to scrub to time " << scrubToTime;
+        scrubToTime = position;
+    }
+    else {
         [moviePlayer setCurrentTime:position];
-	}
+    }
 }
 
 //--------------------------------------------------------------
@@ -487,7 +486,7 @@ bool ofxAVFVideoPlayer::setPixelFormat(ofPixelFormat newPixelFormat)
             loadMovie(moviePath);
         }
     }
-	return true;
+    return true;
 }
 
 //--------------------------------------------------------------
@@ -559,17 +558,17 @@ void ofxAVFVideoPlayer::updateTexture()
     if (bTheFutureIsNow == false) return;
     
     if (moviePlayer.textureAllocated) {
-		tex.setUseExternalTextureID(moviePlayer.textureID);
-		
-		ofTextureData& data = tex.getTextureData();
-		data.textureTarget = moviePlayer.textureTarget;
-		data.width = getWidth();
-		data.height = getHeight();
-		data.tex_w = getWidth();
-		data.tex_h = getHeight();
-		data.tex_t = getWidth();
-		data.tex_u = getHeight();
-	}
+        tex.setUseExternalTextureID(moviePlayer.textureID);
+        
+        ofTextureData& data = tex.getTextureData();
+        data.textureTarget = moviePlayer.textureTarget;
+        data.width = getWidth();
+        data.height = getHeight();
+        data.tex_w = getWidth();
+        data.tex_h = getHeight();
+        data.tex_t = getWidth();
+        data.tex_u = getHeight();
+    }
 }
 
 //--------------------------------------------------------------

--- a/src/ofxAVFVideoPlayer.mm
+++ b/src/ofxAVFVideoPlayer.mm
@@ -25,7 +25,7 @@ ofxAVFVideoPlayer::ofxAVFVideoPlayer()
     currentLoopState = OF_LOOP_NORMAL;
     
     bTheFutureIsNow = false;
-	bShouldLoadAudio = false; // maybe: dont change previouse default behaviour and set this to true
+	bShouldLoadAudio = true; // maybe: change previous default behaviour: explicitly wanting to load audio
 }
 
 //--------------------------------------------------------------
@@ -79,7 +79,12 @@ void ofxAVFVideoPlayer::close()
 	
     if (moviePlayer != nil) {
 		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-        [moviePlayer autorelease];
+		
+		// finalize movieplayer!!
+		// problems when just releasing the object
+		// due to retained moviePlayer
+		// if loading audio and it never got played timeObserver retains moviePlayer
+		[moviePlayer finalize];
         moviePlayer = nil;
 		[pool release];
 

--- a/src/ofxAVFVideoRenderer.h
+++ b/src/ofxAVFVideoRenderer.h
@@ -24,13 +24,13 @@
     // New school video stuff
     AVPlayerItemVideoOutput * _playerItemVideoOutput;
     CVOpenGLTextureCacheRef _textureCache;
-	CVOpenGLTextureRef _latestTextureFrame;
-	CVPixelBufferRef _latestPixelFrame;
+    CVOpenGLTextureRef _latestTextureFrame;
+    CVPixelBufferRef _latestPixelFrame;
 
     // Old school video stuff
     CARenderer * _layerRenderer;
     
-	BOOL _useTexture;
+    BOOL _useTexture;
     BOOL _useAlpha;
     
     CGSize _videoSize;
@@ -43,18 +43,18 @@
     
     BOOL _bLoading;
     BOOL _bLoaded;
-	BOOL _bShouldLoadAudio;
+    BOOL _bShouldLoadAudio;
     BOOL _bAudioLoaded;
     BOOL _bPaused;
     BOOL _bMovieDone;
-    	
+    
     // New school audio stuff
     NSMutableData *_amplitudes;
     int _numAmplitudes;
     __block id _periodicTimeObserver;  // dont copy that, use it directly in the block
-	
-	AVAssetReader* assetReader;
-	dispatch_queue_t evQ;
+    
+    AVAssetReader* assetReader;
+    dispatch_queue_t evQ;
 }
 
 @property (nonatomic, retain) AVPlayer * player;
@@ -108,7 +108,7 @@
 // Old school video stuff
 - (void)render;
 
-// do some cleanup!
+// do some cleanup
 - (void)cleanup;
 - (void)finalize;
 

--- a/src/ofxAVFVideoRenderer.h
+++ b/src/ofxAVFVideoRenderer.h
@@ -108,4 +108,8 @@
 // Old school video stuff
 - (void)render;
 
+// do some cleanup!
+- (void)cleanup;
+- (void)finalize;
+
 @end

--- a/src/ofxAVFVideoRenderer.h
+++ b/src/ofxAVFVideoRenderer.h
@@ -22,7 +22,7 @@
     AVPlayerItem * _playerItem;
 
     // New school video stuff
-    id _playerItemVideoOutput;
+    AVPlayerItemVideoOutput * _playerItemVideoOutput;
     CVOpenGLTextureCacheRef _textureCache;
 	CVOpenGLTextureRef _latestTextureFrame;
 	CVPixelBufferRef _latestPixelFrame;
@@ -43,6 +43,7 @@
     
     BOOL _bLoading;
     BOOL _bLoaded;
+	BOOL _bShouldLoadAudio;
     BOOL _bAudioLoaded;
     BOOL _bPaused;
     BOOL _bMovieDone;
@@ -50,7 +51,10 @@
     // New school audio stuff
     NSMutableData *_amplitudes;
     int _numAmplitudes;
-    id _periodicTimeObserver;
+    __block id _periodicTimeObserver;  // dont copy that, use it directly in the block
+	
+	AVAssetReader* assetReader;
+	dispatch_queue_t evQ;
 }
 
 @property (nonatomic, retain) AVPlayer * player;
@@ -62,6 +66,7 @@
 
 @property (nonatomic, assign, readonly, getter = isLoading) BOOL bLoading;
 @property (nonatomic, assign, readonly, getter = isLoaded) BOOL bLoaded;
+@property (nonatomic, assign) BOOL shouldLoadAudio;
 @property (nonatomic, assign, readonly, getter = isAudioLoaded) BOOL bAudioLoaded;
 @property (nonatomic, assign, getter = isPaused, setter = setPaused:) BOOL bPaused;
 @property (nonatomic, assign, readonly, getter = isMovieDone) BOOL bMovieDone;


### PR DESCRIPTION
Hi.

I came across this, when i was using the threaded-version of ofxAVFVideoPlayer (ofxAVFThreadedVideoPlayer).

Actually this PR contains two changes. It might be "better" to seperate the to things, but somehow they are related.

First:
I added a switch to control if the audio gets loaded into the internal buffer or not. The default behavior is how it was before the change (loading audio)
getter: shouldLoadAudio, setter: setShouldLoadAudio:

Second:
When i was testing with the threaded version for a longer time i came across a memory leak. i digged in and found the following:
- when destroying (or closing) the ofxAVFVideoPlayer and if it was never played (but a file was loaded), the moviePlayer object was not getting freed because the timeObserver holds a reference to it.
- even if cleaning up the timeObserver there was something else going on. so i made sure, that the blocks scheduled by the timeObserver are not holding a reference to the moviePlayer object. Using __block variables and a __block reference to self (in ofxAVFVideoRenderer)
- i created the dispatch_queue before using it, in order to be able to sync with the queue and to free it on cleanup
- a memory-leak at the first iteration when reading audio-data. sampleBuffer has to be released.
